### PR TITLE
Feature fix incorrect get attachment logic

### DIFF
--- a/database/reset.sql
+++ b/database/reset.sql
@@ -60,7 +60,8 @@ insert into public.user (email_address) values
 ('manager@example.com'),
 ('basic_user_a@example.com'),
 ('basic_user_b@example.com'),
-('basic_user_c@example.com');
+('basic_user_c@example.com'),
+('no_access_user@example.com');
 
 -- set up manager access for kevin
 insert into public.user_to_user_access_level (user_id, access_level_id) values
@@ -102,6 +103,14 @@ insert into public.user_to_user_access_level (user_id, access_level_id) values
 ),
 (
     (select id from public.user where email_address='basic_user_b@example.com'),
+    (select id from public.user_access_level where description='View Attachments')
+),
+(
+    (select id from public.user where email_address='basic_user_c@example.com'),
+    (select id from public.user_access_level where description='Create Data')
+),
+(
+    (select id from public.user where email_address='basic_user_c@example.com'),
     (select id from public.user_access_level where description='View Attachments')
 );
 

--- a/rest-client/test/restclient_test.js
+++ b/rest-client/test/restclient_test.js
@@ -2287,7 +2287,7 @@ exports['getAttachment'] = {
           clientUUID,
           'admin@example.com',
           'admin@example.com',
-          'manager@example.com'
+          'no-access-user@example.com'
         );
       }
     ).then(
@@ -2310,7 +2310,7 @@ exports['getAttachment'] = {
       function(getRestrictedResponse) {
         test.doesNotThrow( function() {
           test.equal(getRestrictedResponse.status.code, 403,
-            'get attachment should fail with 401');
+            'get attachment should fail with 403');
         });
 
         //try to retrieve attachment that doesn't exist as restricted user

--- a/web-service/src/web_service/data.clj
+++ b/web-service/src/web_service/data.clj
@@ -1051,16 +1051,14 @@
                                      :row-fn format-attachment-get))
         attachment-own (first (sql/query (db)
                                          [query-own uuid filename email-address]
-                                         :row-fn format-attachment-get))
-        attachment-count (count (:headers attachment))
-        attachment-own-count (count (:headers attachment-own))]
+                                         :row-fn format-attachment-get))]
     (if can-access
-      (if (> attachment-count 0)
+      (if (not (nil? attachment))
         attachment
         (status (response {:response "File not found."}) 404))
-      (if (> attachment-own-count 0)
+      (if (not (nil? attachment-own))
         attachment-own
-        (if (= attachment-count attachment-own-count 0)
+        (if (= attachment attachment-own nil)
           (status (response {:response "File not found."}) 404)
           (do
             (log/debug (format (str "User %s tried to download attachment '%s' "

--- a/web-service/src/web_service/data.clj
+++ b/web-service/src/web_service/data.clj
@@ -1181,20 +1181,18 @@
                                      :row-fn format-attachment-get))
         attachment-own (first (sql/query (db)
                                          [query-own uuid filename email-address]
-                                         :row-fn format-attachment-get))
-        attachment-count (count (:headers attachment))
-        attachment-own-count (count (:headers attachment-own))]
+                                         :row-fn format-attachment-get))]
 
     (if can-access
-      (if (> attachment-count 0)
+      (if (not (nil? attachment))
         ; generate sharable download link
         (generate-sharable-download-link
           email-address uuid filename exp-date end-point-url)
         (status (response {:response "File not found."}) 404))
-      (if (> attachment-own-count 0)
+      (if (not (nil? attachment-own))
         (generate-sharable-download-link
           email-address uuid filename exp-date end-point-url)
-        (if (= attachment-count attachment-own-count 0)
+        (if (= attachment attachment-own nil)
           (status (response {:response "File not found."}) 404)
           (do
             (log/debug (format (str "User %s tried to create a sharable "

--- a/web-service/src/web_service/shared_init.clj
+++ b/web-service/src/web_service/shared_init.clj
@@ -8,7 +8,7 @@
 (defn init
   []
   ; update the database
-  (schema/update)
+  ;(schema/update)
 
   (let [ch (amqp/connect)]
     ; listen for incoming authentications and just print to the standard out


### PR DESCRIPTION
@kevinmershon for your review.  After updating the manager@example.com access levels, this broke a restclient test that assumed manager didn't have the view-attachments access level.  After updated the reset.sh script and adding the no_access_user@example.com user to use for that restclient test instead, I discovered that `data-set-attachment-get` and `data-set-attachment-sharable-download-link` were using incorrect logic to determine a file was restricted or not found.  I've fixed that logic and I've also commented out the this line https://github.com/mershon-enterprises/hydra-core/blob/development/web-service/src/web_service/shared_init.clj#L11 to make development stable again, until I can fix the liquibase changelogs.