### PR TITLE
Feature fix capitalization problem

### DIFF
--- a/web-service/src/web_service/user.clj
+++ b/web-service/src/web_service/user.clj
@@ -26,16 +26,19 @@
 
   ; let a user view their own information but not the information of others,
   ; unless they have the Manage Users access
-  (let [access (set (get-user-access email-address))
-        can-access (or (= target-user-email-address email-address)
+  (let [sanitized-email (-> (or target-user-email-address "")
+                            (.trim)
+                            (.toLowerCase))
+        access (set (get-user-access email-address))
+        can-access (or (= sanitized-email  email-address)
                        (contains? access constants/manage-users))]
     (if can-access
-      (let [user (get-user target-user-email-address)]
+      (let [user (get-user sanitized-email  )]
         ; log the activity in the session
         (log-detail email-address
                     constants/session-activity
                     (str constants/session-get-user " "
-                         target-user-email-address))
+                         sanitized-email  ))
         (if user
           (response {:response user})
           (not-found "User not found"))) ; inconceivable!
@@ -71,11 +74,14 @@
 
   ; let a user view their own information but not the information of others,
   ; unless they have the Manage Users access
-  (let [access (set (get-user-access email-address))
-        can-access (or (= email-address target-email-address)
+  (let [sanitized-email (-> (or target-email-address "")
+                            (.trim)
+                            (.toLowerCase))
+        access (set (get-user-access email-address))
+        can-access (or (= email-address sanitized-email )
                        (contains? access constants/manage-users))]
     (if can-access
-      (response {:response (get-user-access target-email-address)})
+      (response {:response (get-user-access sanitized-email )})
       (access-denied constants/manage-users))))
 
 


### PR DESCRIPTION
@kevinmershon Issue #13 These changes add sanitation on target-email-address parameters passed into `user-get`, `user-access-list` and `user-access-add` methods.  I noticed that `user-access-add` response for conflict would be returned on wrongly spelled target-email-address or access-level.  I wrote in the logic to check parameters before the insert query.  It looks like the conflict response won't ever run because the `user-to-user-access-level` doesn't have a constraint for user_id and access_level_id.  This results it multiple rows for the for the same access-level and user. I'll leave this for another issue.  Otherwise, sanitation for email parameters has been implemented.