### PR TITLE
Feature client metadata

### DIFF
--- a/database/changelog.xml
+++ b/database/changelog.xml
@@ -17,6 +17,7 @@
     <include relativeToChangelogFile="true" file="changelogs/0006-api-token-client-uuid.xml"/>
     <include relativeToChangelogFile="true" file="changelogs/0007-filename-unique-if-not-deleted.xml"/>
     <include relativeToChangelogFile="true" file="changelogs/0008-attachment-sharing-tables.xml"/>
+    <include relativeToChangelogFile="true" file="changelogs/0009-client-metadata-tables.xml"/>
 
     <!-- add child changelogs above this line -->
 

--- a/database/changelogs/0009-client-metadata-tables.xml
+++ b/database/changelogs/0009-client-metadata-tables.xml
@@ -40,13 +40,11 @@
         </column>
       </createTable>
 
-      <addUniqueConstraint
-        constraintName="unique_client_key_name"
-        tableName="client_metadata"
-        columnNames="id, key_name"
-        deferrable="true"
-        disabled="true"
-        initiallyDeferred="true"/>
+      <sql>
+        CREATE UNIQUE INDEX unique_client_id_key_name
+        ON client_metadata(client_id, key_name)
+        WHERE date_deleted IS NULL
+      </sql>
 
       <addForeignKeyConstraint
         constraintName="fk_client_metadata_to_client"

--- a/database/changelogs/0009-client-metadata-tables.xml
+++ b/database/changelogs/0009-client-metadata-tables.xml
@@ -23,6 +23,10 @@
           <constraints nullable="false" />
         </column>
 
+        <column name="deleted_by" type="bigint">
+          <constraints nullable="true" />
+        </column>
+
         <column name="key_name" type="character varying(255)">
           <constraints nullable="false"/>
         </column>
@@ -61,6 +65,17 @@
         constraintName="fk_client_metadata_to_created_by"
         baseTableName="client_metadata"
         baseColumnNames="created_by"
+        referencedTableName="user"
+        referencedColumnNames="id"
+        deferrable="false"
+        initiallyDeferred="false"
+        onDelete="CASCADE"
+        onUpdate="RESTRICT"/>
+
+      <addForeignKeyConstraint
+        constraintName="fk_client_metadata_to_deleted_by"
+        baseTableName="client_metadata"
+        baseColumnNames="deleted_by"
         referencedTableName="user"
         referencedColumnNames="id"
         deferrable="false"

--- a/database/changelogs/0009-client-metadata-tables.xml
+++ b/database/changelogs/0009-client-metadata-tables.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <changeSet id="9" author="Cristopher Pascua">
+      <createTable schemaName="public" tableName="client_metadata">
+        <column name="id" type="bigserial">
+          <constraints primaryKey="true" nullable="false" />
+        </column>
+
+        <column name="client_id" type="bigint">
+          <constraints nullable="false" />
+        </column>
+
+        <column name="user_id" type="bigint">
+          <constraints nullable="false" />
+        </column>
+
+        <column name="key_name" type="character varying(255)">
+          <constraints nullable="false"/>
+        </column>
+
+        <column name="key_value" type="text">
+          <constraints nullable="false"/>
+        </column>
+
+        <column name="date_created" type="timestamp with time zone" defaultValue="NOW()">
+          <constraints nullable="false" />
+        </column>
+
+        <column name="date_deleted" type="timestamp with time zone">
+          <constraints nullable="true" />
+        </column>
+      </createTable>
+
+      <addUniqueConstraint
+        constraintName="unique_client_key_name"
+        tableName="client_metadata"
+        columnNames="id, key_name"
+        deferrable="true"
+        disabled="true"
+        initiallyDeferred="true"/>
+
+      <addForeignKeyConstraint
+        constraintName="fk_client_metadata_to_client"
+        baseColumnNames="client_id"
+        baseTableName="client_metadata"
+        referencedTableName="client"
+        referencedColumnNames="id"
+        deferrable="false"
+        initiallyDeferred="false"
+        onDelete="CASCADE"
+        onUpdate="RESTRICT"/>
+
+      <addForeignKeyConstraint
+        constraintName="fk_client_metadata_to_user"
+        baseColumnNames="client_id"
+        baseTableName="client_metadata"
+        referencedTableName="user"
+        referencedColumnNames="id"
+        deferrable="false"
+        initiallyDeferred="false"
+        onDelete="CASCADE"
+        onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/database/changelogs/0009-client-metadata-tables.xml
+++ b/database/changelogs/0009-client-metadata-tables.xml
@@ -19,7 +19,7 @@
           <constraints nullable="false" />
         </column>
 
-        <column name="user_id" type="bigint">
+        <column name="created_by" type="bigint">
           <constraints nullable="false" />
         </column>
 
@@ -50,8 +50,8 @@
 
       <addForeignKeyConstraint
         constraintName="fk_client_metadata_to_client"
-        baseColumnNames="client_id"
         baseTableName="client_metadata"
+        baseColumnNames="client_id"
         referencedTableName="client"
         referencedColumnNames="id"
         deferrable="false"
@@ -60,9 +60,9 @@
         onUpdate="RESTRICT"/>
 
       <addForeignKeyConstraint
-        constraintName="fk_client_metadata_to_user"
-        baseColumnNames="client_id"
+        constraintName="fk_client_metadata_to_created_by"
         baseTableName="client_metadata"
+        baseColumnNames="created_by"
         referencedTableName="user"
         referencedColumnNames="id"
         deferrable="false"

--- a/rest-client/src/restclient.js
+++ b/rest-client/src/restclient.js
@@ -156,6 +156,17 @@
     });
   };
 
+  exports.listClientMetaData = function(clientUUID, apiToken, name) {
+    return rest({
+      method: 'GET',
+      path: exports.endpointUrl + '/clients/' + name + '/metadata',
+      params: {
+        client_uuid: clientUUID,
+        api_token: apiToken,
+      }
+    });
+  };
+
   exports.listData = function(clientUUID, apiToken, searchParams) {
     if (!searchParams)
       searchParams = '';

--- a/web-service/resources/queries/client_metadata.sql
+++ b/web-service/resources/queries/client_metadata.sql
@@ -30,6 +30,36 @@ inner join "client" c on c.id = ncm.client_id
 inner join "user"   u on u.id = ncm.created_by
 ; --
 
+-- name: get-client-metadata
+with
+  valid_client as
+  (select id from "client" where name = :client_name),
+
+  valid_user as
+  (select id from "user"
+   where email_address = :email_address)
+
+select
+  cm.key_name,
+  cm.key_value,
+  u.email_address as last_updated_by,
+  c.name as client_name
+
+from "client_metadata" cm
+inner join "client" c on c.id = cm.client_id
+inner join "user"   u on u.id = cm.created_by
+
+where cm.client_id = (select id from valid_client)
+
+  and cm.key_name = :key_name
+
+  and case when (nullif(:email_address, null) is null) then true
+      else cm.created_by = (select id from valid_user) end
+
+  and cm.date_deleted is null;
+
+
+
 -- name: get-client-metadata-list-by-client-name
 with
   valid_client as

--- a/web-service/resources/queries/client_metadata.sql
+++ b/web-service/resources/queries/client_metadata.sql
@@ -30,7 +30,7 @@ inner join "client" c on c.id = ncm.client_id
 inner join "user"   u on u.id = ncm.created_by
 ; --
 
--- name: get-client-metadata-list
+-- name: get-client-metadata-list-by-client-name
 with
   valid_client as
   (select id from "client" where name = :client_name)

--- a/web-service/resources/queries/client_metadata.sql
+++ b/web-service/resources/queries/client_metadata.sql
@@ -23,7 +23,7 @@ with
 select
   ncm.key_name,
   ncm.key_value,
-  u.email_address,
+  u.email_address as last_updated_by,
   c.name as client_name
 from new_client_metadata ncm
 inner join "client" c on c.id = ncm.client_id
@@ -72,7 +72,7 @@ with
 select
   cm.key_name,
   cm.key_value,
-  u.email_address,
+  u.email_address as last_updated_by,
   c.name as client_name
 
 from "client_metadata" cm
@@ -108,7 +108,7 @@ select
   dcm.key_value,
   dcm.date_created,
   dcm.date_deleted,
-  cbu.email_address created_by,
+  cbu.email_address last_updated_by,
   dbu.email_address deleted_by,
   c.name as client_name
 from deleted_client_metadata dcm

--- a/web-service/resources/queries/client_metadata.sql
+++ b/web-service/resources/queries/client_metadata.sql
@@ -66,7 +66,8 @@ with
 
   deleted_client_metadata as
   (update "client_metadata"
-   set date_deleted = now()
+   set date_deleted = now(),
+       deleted_by = (select id from valid_user)
    where key_name = :key_name
      and client_id = (select id from valid_client)
      and date_deleted is null
@@ -77,9 +78,11 @@ select
   dcm.key_value,
   dcm.date_created,
   dcm.date_deleted,
-  u.email_address,
+  cbu.email_address created_by,
+  dbu.email_address deleted_by,
   c.name as client_name
 from deleted_client_metadata dcm
 inner join "client" c on c.id = dcm.client_id
-inner join "user"   u on u.id = dcm.created_by
+inner join "user"   cbu on cbu.id = dcm.created_by
+inner join "user"   dbu on dbu.id = dcm.deleted_by
 ; --

--- a/web-service/resources/queries/client_metadata.sql
+++ b/web-service/resources/queries/client_metadata.sql
@@ -39,13 +39,22 @@ with
   (select id from "user"
    where email_address = :email_address)
 
-select * from "client_metadata"
-where client_id = (select id from valid_client)
+select
+  cm.key_name,
+  cm.key_value,
+  u.email_address,
+  c.name as client_name
+
+from "client_metadata" cm
+inner join "client" c on c.id = cm.client_id
+inner join "user"   u on u.id = cm.created_by
+
+where cm.client_id = (select id from valid_client)
 
   and case when (nullif(:email_address, null) is null) then true
-      else created_by = (select id from valid_user) end
+      else cm.created_by = (select id from valid_user) end
 
-  and date_deleted is null;
+  and cm.date_deleted is null;
 
 -- name: delete-client-metadata<!
 with

--- a/web-service/resources/queries/client_metadata.sql
+++ b/web-service/resources/queries/client_metadata.sql
@@ -33,10 +33,18 @@ inner join "user"   u on u.id = ncm.created_by
 -- name: get-client-metadata-list-by-client-name
 with
   valid_client as
-  (select id from "client" where name = :client_name)
+  (select id from "client" where name = :client_name),
+
+  valid_user as
+  (select id from "user"
+   where email_address = :email_address)
 
 select * from "client_metadata"
 where client_id = (select id from valid_client)
+
+  and case when (nullif(:email_address, null) is null) then true
+      else created_by = (select id from valid_user) end
+
   and date_deleted is null;
 
 -- name: delete-client-metadata<!

--- a/web-service/resources/queries/client_metadata.sql
+++ b/web-service/resources/queries/client_metadata.sql
@@ -1,0 +1,68 @@
+-- name: add-client-metadata<!
+with
+  valid_user as
+  (select id from "user"
+   where email_address = :email_address),
+
+  valid_client as
+  (select id from "client" where name = :client_name),
+
+  new_client_metadata as
+  (insert into "client_metadata" (
+     client_id,
+     created_by,
+     key_name,
+     key_value
+  ) values (
+    (select id from valid_client),
+    (select id from valid_user),
+    :key_name,
+    :key_value
+  ) returning *)
+
+select
+  ncm.key_name,
+  ncm.key_value,
+  u.email_address,
+  c.name as client_name
+from new_client_metadata ncm
+inner join "client" c on c.id = ncm.client_id
+inner join "user"   u on u.id = ncm.created_by
+; --
+
+-- name: get-client-metadata-list
+with
+  valid_client as
+  (select id from "client" where name = :client_name)
+
+select * from "client_metadata"
+where client_id = (select id from valid_client)
+  and date_deleted is null;
+
+-- name: delete-client-metadata<!
+with
+  valid_client as
+  (select id from "client" where name = :client_name),
+
+  valid_user as
+  (select id from "user" where email_address = :email_address),
+
+  deleted_client_metadata as
+  (update "client_metadata"
+   set date_deleted = now()
+   where key_name = :key_name
+     and client_id = (select id from valid_client)
+     and date_deleted is null
+   returning *)
+
+select
+  dcm.key_name,
+  dcm.key_value,
+  dcm.date_created,
+  dcm.date_deleted,
+  u.email_address,
+  c.name as client_name
+from deleted_client_metadata dcm
+inner join "client" c on c.id = dcm.client_id
+inner join "user"   u on u.id = dcm.created_by
+; --

--- a/web-service/src/web_service/client_metadata.clj
+++ b/web-service/src/web_service/client_metadata.clj
@@ -1,0 +1,44 @@
+(ns web-service.client-metadata
+  (:use [ring.util.response]
+        [web-service.db]
+        [web-service.session]
+        [web-service.user-helpers]
+        [web-service.authentication])
+  (:require [clojure.java.jdbc :as sql]
+            [clojure.string :as string]
+            [clojure.tools.logging :as log]
+            [clojure.data.codec.base64 :as b64]
+            [cheshire.core :refer :all]
+            [web-service.amqp :as amqp]
+            [hydra.constants :as constants]
+            [web-service.schema :as queries :include-macros true])
+  (:import java.sql.SQLException
+           org.apache.commons.lang.RandomStringUtils))
+
+(defn add-client-metadata!
+  [& {:keys [key_name
+             client_name
+             email_address
+             key_value
+             ] :as args}]
+  (log/debug "add-client-metadata!")
+  (log/debug "args:   " args)
+  ; users who can view or manage clients can see information about a client
+
+  (let [access     (set (get-user-access email_address))
+        can-access true #_(contains? access constants/manage-clients)]
+
+    (if-let [client_metadata (and
+                               can-access
+                               (queries/add-client-metadata<!
+                                 {:client_name   client_name
+                                  :email_address email_address
+                                  :key_name      key_name
+                                  :key_value     key_value}
+                                 {:result-set-fn first}))]
+
+      (if client_metadata
+        (response {:response client_metadata})
+        (not-found "client metadata not found"))
+
+      (access-denied (str constants/manage-clients)))))

--- a/web-service/src/web_service/client_metadata.clj
+++ b/web-service/src/web_service/client_metadata.clj
@@ -55,7 +55,7 @@
         restrict_email_address (if can-manage-data nil email_address)]
 
     (if can-access
-      (let [client_metadata (queries/get-client-metadata-list-by-client-name
+      (let [client_metadata (queries/get-client-metadata
                               {:client_name   client_name
                                :email_address restrict_email_address
                                :key_name      key_name}

--- a/web-service/src/web_service/client_metadata.clj
+++ b/web-service/src/web_service/client_metadata.clj
@@ -15,6 +15,14 @@
   (:import java.sql.SQLException
            org.apache.commons.lang.RandomStringUtils))
 
+(defn do-get-client-metadata
+  [client_name key_name email_address]
+  (queries/get-client-metadata
+    {:client_name   client_name
+     :email_address (or email_address nil)
+     :key_name      key_name}
+    {:result-set-fn first}))
+
 (defn add-client-metadata!
   [email_address & {:keys [key_name
                            client_name
@@ -60,11 +68,10 @@
           restrict_email_address (if can-manage-data nil email_address)]
 
       (if can-access
-        (let [client_metadata (queries/get-client-metadata
-                                {:client_name   client_name
-                                 :email_address restrict_email_address
-                                 :key_name      key_name}
-                                {:result-set-fn first})]
+        (let [client_metadata (do-get-client-metadata
+                                client_name
+                                restrict_email_address
+                                key_name)]
 
           (if client_metadata
             (response {:response client_metadata})

--- a/web-service/src/web_service/client_metadata.clj
+++ b/web-service/src/web_service/client_metadata.clj
@@ -24,7 +24,6 @@
   {:pre [true] :post [true]} ;FIXME add spec validators
   (log/debug "add-client-metadata!")
   (log/debug "args:   " args)
-  ; users who can view or manage clients can see information about a client
 
   (let [access     (set (get-user-access email_address))
         can-access (contains? access constants/manage-clients)]
@@ -51,7 +50,6 @@
   (log/debug "get-client-metadata")
   (log/debug "args:   " args)
 
-  ;[View Data | Manage Data] AND [View Clients | Manage Clients]
   (let [access          (set (get-user-access email_address))
         can-access      (or (contains? access constants/view-clients)
                             (contains? access constants/manage-clients))

--- a/web-service/src/web_service/client_metadata.clj
+++ b/web-service/src/web_service/client_metadata.clj
@@ -21,12 +21,13 @@
              email_address
              key_value
              ] :as args}]
+  {:pre [true] :post [true]} ;FIXME add spec validators
   (log/debug "add-client-metadata!")
   (log/debug "args:   " args)
   ; users who can view or manage clients can see information about a client
 
   (let [access     (set (get-user-access email_address))
-        can-access true #_(contains? access constants/manage-clients)]
+        can-access (contains? access constants/manage-clients)]
 
     (if-let [client_metadata (and
                                can-access

--- a/web-service/src/web_service/client_metadata.clj
+++ b/web-service/src/web_service/client_metadata.clj
@@ -16,11 +16,9 @@
            org.apache.commons.lang.RandomStringUtils))
 
 (defn add-client-metadata!
-  [& {:keys [key_name
-             client_name
-             email_address
-             key_value
-             ] :as args}]
+  [email_address & {:keys [key_name
+                           client_name
+                           key_value] :as args}]
   {:pre [true] :post [true]} ;FIXME add spec validators
   (log/debug "add-client-metadata!")
   (log/debug "args:   " args)
@@ -43,9 +41,8 @@
       (access-denied (str constants/manage-clients)))))
 
 (defn get-client-metadata
-  [& {:keys [client_name
-             email_address
-             key_name] :as args}]
+  [email_address & {:keys [client_name
+                           key_name] :as args}]
   {:pre [true] :post [true]} ;FIXME add spec validators
   (log/debug "get-client-metadata")
   (log/debug "args:   " args)
@@ -71,8 +68,7 @@
       (access-denied (str constants/manage-clients)))))
 
 (defn get-client-metadata-list
-  [& {:keys [client_name
-             email_address] :as args}]
+  [email_address & {:keys [client_name] :as args}]
   {:pre [true] :post [true]} ;FIXME add spec validators
   (log/debug "get-client-metadata-list")
   (log/debug "args:   " args)
@@ -96,9 +92,8 @@
       (access-denied (str constants/manage-clients)))))
 
 (defn delete-client-metadata!
-  [& {:keys [client_name
-             email_address
-             key_name] :as args}]
+  [email_address & {:keys [client_name
+                           key_name] :as args}]
   {:pre [true] :post [true]} ;FIXME add spec validators
   (log/debug "delete-client-metadata!")
   (log/debug "args:   " args)
@@ -120,10 +115,9 @@
       (access-denied (str constants/manage-clients)))))
 
 (defn update-client-metadata!
-  [& {:keys [client_name
-             email_address
-             key_name
-             key_value] :as args}]
+  [email_address & {:keys [client_name
+                           key_name
+                           key_value] :as args}]
   {:pre [true] :post [true]} ;FIXME add spec validators
   (log/debug "update-client-metadata!")
   (log/debug "args:   " args)

--- a/web-service/src/web_service/data.clj
+++ b/web-service/src/web_service/data.clj
@@ -278,9 +278,8 @@
    (let [query-own (str data-set-attachment-query
                         "and uuid::character varying=? "
                         "and dsa.filename=? "
-                        "and u.email_address=? "
                         "order by data_set_attachment_id ")]
-     (first (sql/query (db) [query-own email-address uuid filename email-address]
+     (first (sql/query (db) [query-own email-address uuid filename]
                        :row-fn format-attachment-info)))) )
 
 

--- a/web-service/src/web_service/handler.clj
+++ b/web-service/src/web_service/handler.clj
@@ -91,8 +91,7 @@
                     (guard-with-user
                       api_token client_uuid
                       delete-client-metadata! :client_name name
-                                              :key_name    key_name))
-                           ))))
+                                              :key_name    key_name))))))
           (context
             "/locations" []
             (defroutes document-routes

--- a/web-service/src/web_service/handler.clj
+++ b/web-service/src/web_service/handler.clj
@@ -3,6 +3,7 @@
 
         [web-service.authentication]
         [web-service.client]
+        [web-service.client-metadata]
         [web-service.data]
         [web-service.user])
   (:require [compojure.core :refer :all]
@@ -62,13 +63,36 @@
           (context
             "/metadata" []
             (defroutes document-routes
-              (GET "/" [] (not-implemented "Get metadata"))
-              (POST "/" [] (not-implemented "Add metadata"))
+              (GET "/" [api_token client_uuid]
+                 (guard-with-user
+                  api_token client_uuid
+                  get-client-metadata-list :client_name name))
+              (POST "/" [api_token client_uuid key_name key_value]
+                (guard-with-user
+                  api_token client_uuid
+                  add-client-metadata! :client_name name
+                                       :key_name   key_name
+                                       :key_value  key_value))
               (context
                 "/:key_name" [key_name]
                 (defroutes document-routes
-                  (PUT "/" [] (not-implemented "Update metadata"))
-                  (DELETE "/" [] (not-implemented "Delete metadata"))))))
+                  (GET "/" [api_token client_uuid]
+                    (guard-with-user
+                      api_token client_uuid
+                      get-client-metadata :client_name name
+                                          :key_name    key_name))
+                  (PUT "/" [api_token client_uuid key_value]
+                    (guard-with-user
+                      api_token client_uuid
+                      update-client-metadata! :client_name name
+                                              :key_name    key_name
+                                              :key_value   key_value))
+                  (DELETE "/" [api_token client_uuid]
+                    (guard-with-user
+                      api_token client_uuid
+                      delete-client-metadata! :client_name name
+                                              :key_name    key_name))
+                           ))))
           (context
             "/locations" []
             (defroutes document-routes

--- a/web-service/src/web_service/handler.clj
+++ b/web-service/src/web_service/handler.clj
@@ -60,6 +60,16 @@
                 (guard-with-user api_token client_uuid client-register name))
           (DELETE "/" [] (not-allowed "Delete client"))
           (context
+            "/metadata" []
+            (defroutes document-routes
+              (GET "/" [] (not-implemented "Get metadata"))
+              (POST "/" [] (not-implemented "Add metadata"))
+              (context
+                "/:key_name" [key_name]
+                (defroutes document-routes
+                  (PUT "/" [] (not-implemented "Update metadata"))
+                  (DELETE "/" [] (not-implemented "Delete metadata"))))))
+          (context
             "/locations" []
             (defroutes document-routes
               (GET "/" [api_token client_uuid]

--- a/web-service/src/web_service/log4j.properties
+++ b/web-service/src/web_service/log4j.properties
@@ -1,4 +1,26 @@
-log4j.rootLogger=DEBUG, console
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%-5p %c: %m%n
+log4j.appender.R=org.apache.log4j.RollingFileAppender
+log4j.appender.R.File=log/system.log
+log4j.appender.R.MaxFileSize=4096KB
+log4j.appender.R.MaxBackupIndex=9
+log4j.appender.R.layout=org.apache.log4j.PatternLayout
+log4j.appender.R.layout.ConversionPattern=[%d][%p][%c] %m%n
+log4j.logger.R=INFO, R
+
+log4j.rootLogger=INFO, R
+
+log4j.appender.hydra=org.apache.log4j.RollingFileAppender
+log4j.appender.hydra.File=log/server.log
+log4j.appender.hydra.MaxFileSize=4096KB
+log4j.appender.hydra.MaxBackupIndex=9
+log4j.appender.hydra.layout=org.apache.log4j.PatternLayout
+log4j.appender.hydra.layout.ConversionPattern=[%d][%p][%c] %m%n
+log4j.additivity.hydra=false
+
+log4j.appender.web-service=org.apache.log4j.RollingFileAppender
+log4j.appender.web-service.File=log/server.log
+log4j.appender.web-service.MaxFileSize=4096KB
+log4j.appender.web-service.MaxBackupIndex=9
+log4j.appender.web-service.layout=org.apache.log4j.PatternLayout
+log4j.appender.web-service.layout.ConversionPattern=[%d][%p][%c] %m%n
+log4j.additivity.web-service=false
+log4j.logger.web-service=DEBUG, hydra, web-service

--- a/web-service/src/web_service/schema.clj
+++ b/web-service/src/web_service/schema.clj
@@ -50,3 +50,13 @@
   []
   (log/info "Applying new liquibase changelogs to database if they exist.")
   (.update (liquibase-instance) nil))
+
+#_(defqueries "queries/client_metadata.sql" {:connection db-spec})
+#_(add-client-metadata<! {:email_address "cristopher@mershonenterprises.com" 
+                          :client_name "MEC"
+                          :key_name "this_key3"
+                          :key_value "this_value3"})
+
+#_(defqueries "queries/client_metadata.sql" {:connection db-spec})
+#_(get-client-metadata-list {:client_name "MEC"})
+

--- a/web-service/src/web_service/schema.clj
+++ b/web-service/src/web_service/schema.clj
@@ -17,11 +17,11 @@
               :user        (env :db-user)
               :password    (env :db-password)})
 
-(defqueries "queries/access_level.sql" {:connection db-spec})
-(defqueries "queries/dataset.sql"      {:connection db-spec})
-(defqueries "queries/session.sql"      {:connection db-spec})
-(defqueries "queries/user.sql"         {:connection db-spec})
-
+(defqueries "queries/access_level.sql"    {:connection db-spec})
+(defqueries "queries/dataset.sql"         {:connection db-spec})
+(defqueries "queries/session.sql"         {:connection db-spec})
+(defqueries "queries/user.sql"            {:connection db-spec})
+(defqueries "queries/client_metadata.sql" {:connection db-spec})
 
 (defn- liquibase-instance
   "Generate liquibase instance using environment variables."

--- a/web-service/src/web_service/schema.clj
+++ b/web-service/src/web_service/schema.clj
@@ -50,13 +50,3 @@
   []
   (log/info "Applying new liquibase changelogs to database if they exist.")
   (.update (liquibase-instance) nil))
-
-#_(defqueries "queries/client_metadata.sql" {:connection db-spec})
-#_(add-client-metadata<! {:email_address "cristopher@mershonenterprises.com" 
-                          :client_name "MEC"
-                          :key_name "this_key3"
-                          :key_value "this_value3"})
-
-#_(defqueries "queries/client_metadata.sql" {:connection db-spec})
-#_(get-client-metadata-list {:client_name "MEC"})
-

--- a/web-service/src/web_service/shared_init.clj
+++ b/web-service/src/web_service/shared_init.clj
@@ -1,4 +1,5 @@
 (ns web-service.shared-init
+  (:use [web-service.client-metadata])
   (:use [web-service.data])
   (:require [clojure.tools.logging :as log]
             [cheshire.core :refer :all]


### PR DESCRIPTION
@kevinmershon this is ready for review although setup to test will take awhile. You will need to create a client, a user, access_levels and user_access_levels.  As we've discuss client_metadata rows are soft deleted but I've added a `deleted_by` column to keep a record user who deleted the row.  The update method soft deletes the current client_metadata by key_name and adds a new row with the same key_name but with the new value.  A constraint exists to allow only one non-deleted key_name row per client_id.